### PR TITLE
Register monster tier 2 and tier 3 filming locations

### DIFF
--- a/ContentWarningArchipelago/Data/LocationData.cs
+++ b/ContentWarningArchipelago/Data/LocationData.cs
@@ -78,6 +78,56 @@ namespace ContentWarningArchipelago.Data
             Register("Filmed Streamer",      328);
             Register("Filmed Ultra Knifo",   329);
 
+            // ==================== MONSTER TIER 2 (offsets 330–350) ====================
+            // Names and offsets must match cw-apworld locations.py exactly.
+            // The APWorld only tiers a subset of monsters; missing entries here
+            // (e.g. Cam Creep, Ear, Flicker, Big Slap) are intentional — those
+            // monsters only have a base check.
+            Register("Filmed Slurper 2",       330);
+            Register("Filmed Zombe 2",         331);
+            Register("Filmed Button Robot 2",  332);
+            Register("Filmed Puffo 2",         333);
+            Register("Filmed Whisk 2",         334);
+            Register("Filmed Arms 2",          335);
+            Register("Filmed Worm 2",          336);
+            Register("Filmed Mouthe 2",        337);
+            Register("Filmed Spider 2",        338);
+            Register("Filmed Bomber 2",        339);
+            Register("Filmed Dog 2",           340);
+            Register("Filmed Eye Guy 2",       341);
+            Register("Filmed Knifo 2",         342);
+            Register("Filmed Larva 2",         343);
+            Register("Filmed Harpooner 2",     344);
+            Register("Filmed Barnacle Ball 2", 345);
+            Register("Filmed Snatcho 2",       346);
+            Register("Filmed Jelly 2",         347);
+            Register("Filmed Fire 2",          348);
+            Register("Filmed Mime 2",          349);
+            Register("Filmed Streamer 2",      350);
+
+            // ==================== MONSTER TIER 3 (offsets 351–371) ====================
+            Register("Filmed Slurper 3",       351);
+            Register("Filmed Zombe 3",         352);
+            Register("Filmed Button Robot 3",  353);
+            Register("Filmed Puffo 3",         354);
+            Register("Filmed Whisk 3",         355);
+            Register("Filmed Arms 3",          356);
+            Register("Filmed Worm 3",          357);
+            Register("Filmed Mouthe 3",        358);
+            Register("Filmed Spider 3",        359);
+            Register("Filmed Bomber 3",        360);
+            Register("Filmed Dog 3",           361);
+            Register("Filmed Eye Guy 3",       362);
+            Register("Filmed Knifo 3",         363);
+            Register("Filmed Larva 3",         364);
+            Register("Filmed Harpooner 3",     365);
+            Register("Filmed Barnacle Ball 3", 366);
+            Register("Filmed Snatcho 3",       367);
+            Register("Filmed Jelly 3",         368);
+            Register("Filmed Fire 3",          369);
+            Register("Filmed Mime 3",          370);
+            Register("Filmed Streamer 3",      371);
+
             // ==================== ARTIFACT FILMING (offsets 400–412) ====================
             Register("Filmed Ribcage",                400);
             Register("Filmed Skull",                  401);


### PR DESCRIPTION
## Summary

Closes #5.

The bug is one missing data table — not a name-translation problem. [LocationData.cs](ContentWarningArchipelago/Data/LocationData.cs) registered the base monster filming locations (offsets 300-329) but never registered the tier-2 and tier-3 entries. The APWorld already had them at offsets 330-371. So when `TryFireEntityCheck` did `LocationData.GetId(\"Filmed Jelly 2\")` it returned -1, the tier-2 branch fell through, and monster multi-checks silently failed.

Artifact tier 2/3 (offsets 413-438) were already registered in `LocationData`, which is exactly why the issue only manifested for monsters.

The fix: add 21 tier-2 entries (330-350) and 21 tier-3 entries (351-371) mirroring `cw-apworld/locations.py` exactly.

## Diagnosis vs. the issue's hypothesis

The issue hypothesised three problems. The first two don't actually match the current code — flagging here in case the framing is useful for future debugging:

1. **\"Name translation disconnect — tracker stores raw `GetName()` instead of translated AP name.\"** Not a bug in the current code. [TryFireEntityCheck](ContentWarningArchipelago/Patches/ItemPickupPatch.cs#L770-L873) resolves the AP location name first (via `FilmingLocationData.TryGetLocationById` / `TryGetLocationByTypeName`), assigns it to `baseLocationName`, then uses that *same* string for both `_monstersFilmedThisDay` dedup and the `+ \" 2\"` / `+ \" 3\"` tier appends. There is no \"Jello vs Jelly\" mismatch happening at runtime.
2. **\"Tracker stores 'Jello' but tries to append '2' to 'Jelly'.\"** Same as above — the dedup key and the tier-append key are the same string variable.
3. **\"Sleep reset hook must not wipe global lifetime count, only daily anti-spam count.\"** The current architecture already does this. `_monstersFilmedThisDay` is the daily anti-spam set (cleared by `ResetDailyFilmingState` from `RPCM_StartGame` and `RPCA_Sleep`). The lifetime gate is `APSave.IsLocationChecked(locId)` reading `saveData.locationsChecked`, which is persisted to disk and never wiped. Tier advancement uses the lifetime gate, not the daily set, so the existing reset semantics are correct. The reason monsters appeared not to advance was that `LocationData.GetId(\"Filmed Jelly 2\")` was returning -1 — so even when the lifetime gate said \"advance to tier 2\", there was no valid AP ID to send.

## Out of scope

- Monsters the APWorld doesn't tier (Cam Creep, Ear, Flicker, Big Slap, Snail Spawner, Black Hole Bot, Infiltrator, Ultra Knifo, Weeping) remain base-only here too, mirroring the APWorld. Adding tiers for them would need APWorld changes first.
- No APWorld PR is needed for this fix — the APWorld already has all the tier-2/tier-3 entries.

## Test plan

- [ ] Build deploys cleanly (already confirmed locally — no new warnings).
- [ ] Connect to an AP slot generated with `monster_tiers` enabled.
- [ ] Day 1: film a monster the APWorld tiers (Jelly, Slurper, Worm, etc.). Confirm `[ContentEvaluatorPatch] Filming check → Filmed Jelly` in the log and that the AP server records the base check.
- [ ] Day 2 (sleep / advance day): film the same monster again. Confirm the log shows `Filming check → Filmed Jelly 2` and the AP server records the tier-2 check.
- [ ] Day 3: same monster again → `Filmed Jelly 3`.
- [ ] Day 4: same monster again → log shows `[ContentEvaluatorPatch] All tiers for 'Filmed Jelly' already checked.` (debug-level) and no further checks fire.
- [ ] Confirm a non-tiered monster (e.g. Cam Creep) still fires base only and silently no-ops on subsequent days (no error, no spam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)