### PR TITLE
Handle new $50 money item (cw-apworld issue #3)

### DIFF
--- a/ContentWarningArchipelago/Data/ItemData.cs
+++ b/ContentWarningArchipelago/Data/ItemData.cs
@@ -46,6 +46,7 @@ namespace ContentWarningArchipelago.Data
         public const int OffsetRescueHook        = 10;
         public const int OffsetShockStick        = 11;
         public const int OffsetDefibrillator     = 12;
+        public const int OffsetMoneyTiny         = 19;   // $50 — added in issue #3 economy overhaul
         public const int OffsetMoneySmall        = 20;
         public const int OffsetMoneyMedium       = 21;
         public const int OffsetMoneyLarge        = 22;
@@ -72,6 +73,7 @@ namespace ContentWarningArchipelago.Data
             Register(OffsetRescueHook,        ItemNames.RescueHook);
             Register(OffsetShockStick,        ItemNames.ShockStick);
             Register(OffsetDefibrillator,     ItemNames.Defibrillator);
+            Register(OffsetMoneyTiny,         ItemNames.MoneyTiny);
             Register(OffsetMoneySmall,        ItemNames.MoneySmall);
             Register(OffsetMoneyMedium,       ItemNames.MoneyMedium);
             Register(OffsetMoneyLarge,        ItemNames.MoneyLarge);
@@ -269,12 +271,16 @@ namespace ContentWarningArchipelago.Data
                 // pendingMoney which MoneyPatch drains on the next InitShop.
                 //
                 // Amounts match items.py exactly:
-                //   $100 (offset 20), $200 (offset 21), $300 (offset 22), $400 (offset 23)
+                //   $50  (offset 19), $100 (offset 20), $200 (offset 21),
+                //   $300 (offset 22), $400 (offset 23)
                 //
                 // HOST PRIORITY: Only the master client applies money grants.
                 // Non-master clients skip these entirely to prevent doubling the
                 // shared wallet when all players receive the same AP item.
                 // ==============================================================
+                case ItemNames.MoneyTiny:    // $50 — ID 98765019
+                    if (PhotonNetwork.IsMasterClient) GrantMoney(50, name, senderName);
+                    break;
                 case ItemNames.MoneySmall:   // $100 — ID 98765020
                     if (PhotonNetwork.IsMasterClient) GrantMoney(100, name, senderName);
                     break;

--- a/ContentWarningArchipelago/Data/ItemNames.cs
+++ b/ContentWarningArchipelago/Data/ItemNames.cs
@@ -27,9 +27,12 @@ namespace ContentWarningArchipelago.Data
         public const string Defibrillator = "Defibrillator";
 
         // ---- Money ($) — filler ----
-        // Names match item_names.py exactly: $100 / $200 / $300 / $400
+        // Names match item_names.py exactly: $50 / $100 / $200 / $300 / $400
         // The values represent the nominal dollar amount shown to the player.
         // In-game the amounts are granted 1-to-1 (i.e. $100 → +$100 in lobby wallet).
+        // $300 is preserved for cheat-console compatibility but is no longer in the
+        // generated pool (apworld removed it from MONEY_FILLER_POOL in issue #3).
+        public const string MoneyTiny   = "$50";    // offset 19 — ID 98765019
         public const string MoneySmall  = "$100";   // offset 20 — ID 98765020
         public const string MoneyMedium = "$200";   // offset 21 — ID 98765021
         public const string MoneyLarge  = "$300";   // offset 22 — ID 98765022


### PR DESCRIPTION
Adds the in-game handler for the new `$50` money denomination introduced by [Jakeodude/cw-apworld#8](https://github.com/Jakeodude/cw-apworld/pull/8). Without this, an arriving `$50` AP item would fall through `HandleReceivedItem`'s `default:` branch, log a warning, and grant nothing.

## Changes
- `Data/ItemNames.cs` — add `MoneyTiny = "$50"` (offset 19 → ID `98765019`).
- `Data/ItemData.cs` — add `OffsetMoneyTiny = 19`, register it in `Init()`, and add a `switch` case that calls `GrantMoney(50, ...)` under the same `PhotonNetwork.IsMasterClient` guard as `$100` / `$200` / `$300` / `$400`.
- `$300` handling is intentionally preserved so the cheat console can still spawn it; the apworld dropped `$300` from `MONEY_FILLER_POOL` but kept its `item_table` entry to keep IDs stable.

## Why this is a separate PR
Cross-repo: this mod and the apworld are versioned independently, so the C# change must land here. Per `CLAUDE.md` branch-hygiene rules, this PR and the apworld PR are an "issue group" that should land together — **do not merge one without the other**, or the in-game economy will be broken in one direction (apworld generates `$50` items the mod can't grant, or the mod knows about `$50` but receives none).

## Test plan
- [x] Solution builds cleanly (`dotnet build cw-archipelago-mod.sln` — 0 errors, only pre-existing warnings).
- [x] Generate a seed from the paired apworld PR and confirm a `$50` pickup increments the lobby wallet by 50 on the host.
- [x] Confirm a non-master client receiving `$50` does not double-credit (master-client guard exercised).
- [x] Confirm `$300` still works via cheat console (regression check).

Pairs with: Jakeodude/cw-apworld#8
Part of: Jakeodude/cw-apworld#3