### PR TITLE
Implement views tracking, sponsorship completion, and slot-data migration (issue #7)

### DIFF
--- a/ContentWarningArchipelago/Core/APSaveData.cs
+++ b/ContentWarningArchipelago/Core/APSaveData.cs
@@ -23,9 +23,37 @@ namespace ContentWarningArchipelago.Core
         /// </summary>
         public int itemReceivedIndex = 0;
 
-        /// <summary>AP slot data values cached on connect (read from server).</summary>
-        public int  quotaCount        = 5;      // how many quotas the world uses
-        public bool viralSensationGoal = true;  // win condition is "Viral Sensation"
+        // ------------------------------------------------------------------ AP slot data cache
+        // Populated on each connect from ArchipelagoSession.SlotData.  Persisted
+        // here so reconnects after a crash still have the values handy without a
+        // re-handshake.  Field names match the apworld fill_slot_data keys
+        // (cw-apworld/__init__.py).  Defaults match the apworld defaults so a
+        // mid-implementation slot that omits a key still behaves sensibly.
+
+        public int  quotaCount       = 5;
+        public bool quotaRequirement = true;
+
+        // Goal toggles — any combination may be active; all enabled goals must
+        // be satisfied to win (AND semantics).  At least one is always on.
+        public bool viralSensationGoal = true;
+        public bool viewsGoal          = false;
+        public bool quotaGoal          = false;
+        public bool monsterHunterGoal  = false;
+        public bool hatCollectorGoal   = false;
+
+        // Goal thresholds.
+        public int viewsGoalTarget     = 500_000;
+        public int monsterHunterCount  = 12;
+        public int hatCollectorCount   = 15;
+
+        // Pool toggles.
+        public bool viewsChecks         = true;
+        public bool includeSponsorships = true;
+        public bool sponsorFiller       = true;
+        public bool difficultMonsters   = false;
+        public bool monsterTiersEnabled = false;
+        public bool fillerMultiSightings = true;
+        public bool multiplayerMode     = false;
 
         // ------------------------------------------------------------------ Progressive item levels
         // These are incremented each time the matching AP item is received and
@@ -99,14 +127,30 @@ namespace ContentWarningArchipelago.Core
         /// </summary>
         public int pendingMoney = 0;
 
-        // ------------------------------------------------------------------ Monster / artifact tiers
+        // ------------------------------------------------------------------ Views tracking
+        // Tracked locally on the master client (the only place AddQuota fires).
+        // Persisted across reconnects so a crash mid-quota doesn't reset
+        // progress.  Quota cycle resets on quota pass/fail.
 
-        /// <summary>
-        /// True when the AP world was generated with <c>monster_tiers</c> enabled.
-        /// Cached from slot data on connect; used by <c>ContentEvaluatorPatch</c> to
-        /// decide whether to attempt tier 2/3 filming checks.
-        /// </summary>
-        public bool monsterTiersEnabled = false;
+        /// <summary>Cumulative views earned across all extractions.  Drives
+        /// the "Reached N Total Views" milestone checks.</summary>
+        public long lifetimeViews = 0L;
+
+        /// <summary>Views earned strictly within the current 3-day quota
+        /// cycle.  Drives the Viral Sensation event (1,000,000 in a quota).
+        /// Reset by NewWeek (success) and RPC_QuotaFailed (failure).</summary>
+        public long currentQuotaViews = 0L;
+
+        /// <summary>True once "Viral Sensation Achieved" has been fired in the
+        /// current quota.  Reset alongside <see cref="currentQuotaViews"/>.</summary>
+        public bool viralSensationFiredThisQuota = false;
+
+        // ------------------------------------------------------------------ Sponsorships
+        // Number of sponsorships completed across the entire AP slot.  Used as
+        // the index for the next "Completed Sponsorship N" check.  Persists
+        // across run loss/restart per issue #5 Q3 (apworld answer 3).
+
+        public int sponsorshipsCompleted = 0;
 
         // ------------------------------------------------------------------ Hat shop (session-only)
 

--- a/ContentWarningArchipelago/Core/ArchipelagoClient.cs
+++ b/ContentWarningArchipelago/Core/ArchipelagoClient.cs
@@ -138,12 +138,10 @@ namespace ContentWarningArchipelago.Core
                 // Initialise (or load) the per-slot save file.
                 APSave.Init(playerName, seed);
 
-                // Cache slot-data values we care about.
-                if (slotData.TryGetValue("quota_count", out var qc))
-                    APSave.saveData.quotaCount = Convert.ToInt32(qc);
-
-                if (slotData.TryGetValue("monster_tiers", out var mt))
-                    APSave.saveData.monsterTiersEnabled = Convert.ToBoolean(mt);
+                // Cache slot-data values we care about.  Keys mirror
+                // cw-apworld/__init__.py fill_slot_data exactly.  Missing keys
+                // leave the APSaveData defaults in place.
+                CacheSlotData();
 
                 // ---- Resync items the server already sent while we were offline ----
                 _itemIndex = APSave.saveData.itemReceivedIndex;
@@ -360,6 +358,47 @@ namespace ContentWarningArchipelago.Core
         }
 
         // ================================================================== HELPERS
+
+        /// <summary>
+        /// Pulls the apworld slot-data dictionary into the per-slot APSaveData
+        /// cache.  Keys mirror <c>cw-apworld/__init__.py</c> <c>fill_slot_data</c>
+        /// exactly.  Missing keys leave the APSaveData defaults in place so a
+        /// future apworld revision that omits a key falls back gracefully.
+        /// </summary>
+        private void CacheSlotData()
+        {
+            if (slotData == null) return;
+            var s = APSave.saveData;
+
+            if (slotData.TryGetValue("quota_count",            out var v)) s.quotaCount            = Convert.ToInt32(v);
+            if (slotData.TryGetValue("quota_requirement",      out v))     s.quotaRequirement      = Convert.ToBoolean(v);
+
+            if (slotData.TryGetValue("viral_sensation",        out v))     s.viralSensationGoal    = Convert.ToBoolean(v);
+            if (slotData.TryGetValue("views_goal",             out v))     s.viewsGoal             = Convert.ToBoolean(v);
+            if (slotData.TryGetValue("quota_goal",             out v))     s.quotaGoal             = Convert.ToBoolean(v);
+            if (slotData.TryGetValue("monster_hunter",         out v))     s.monsterHunterGoal     = Convert.ToBoolean(v);
+            if (slotData.TryGetValue("hat_collector",          out v))     s.hatCollectorGoal      = Convert.ToBoolean(v);
+
+            if (slotData.TryGetValue("views_goal_target",      out v))     s.viewsGoalTarget       = Convert.ToInt32(v);
+            if (slotData.TryGetValue("monster_hunter_count",   out v))     s.monsterHunterCount    = Convert.ToInt32(v);
+            if (slotData.TryGetValue("hat_collector_count",    out v))     s.hatCollectorCount     = Convert.ToInt32(v);
+
+            if (slotData.TryGetValue("views_checks",           out v))     s.viewsChecks           = Convert.ToBoolean(v);
+            if (slotData.TryGetValue("include_sponsorships",   out v))     s.includeSponsorships   = Convert.ToBoolean(v);
+            if (slotData.TryGetValue("sponsor_filler",         out v))     s.sponsorFiller         = Convert.ToBoolean(v);
+            if (slotData.TryGetValue("difficult_monsters",     out v))     s.difficultMonsters     = Convert.ToBoolean(v);
+            if (slotData.TryGetValue("monster_tiers",          out v))     s.monsterTiersEnabled   = Convert.ToBoolean(v);
+            if (slotData.TryGetValue("filler_multi_sightings", out v))     s.fillerMultiSightings  = Convert.ToBoolean(v);
+            if (slotData.TryGetValue("multiplayer_mode",       out v))     s.multiplayerMode       = Convert.ToBoolean(v);
+
+            APSave.Flush();
+
+            Plugin.Logger.LogInfo(
+                $"[AP] Slot data cached — quotaCount={s.quotaCount}, " +
+                $"goals=[viral={s.viralSensationGoal}, views={s.viewsGoal}, quota={s.quotaGoal}, " +
+                $"monsters={s.monsterHunterGoal}, hats={s.hatCollectorGoal}], " +
+                $"viewsTarget={s.viewsGoalTarget}, sponsors={s.includeSponsorships}.");
+        }
 
         /// <summary>
         /// Thread-safe alternative to ActivateCheck when calling from a non-main thread.

--- a/ContentWarningArchipelago/Data/LocationData.cs
+++ b/ContentWarningArchipelago/Data/LocationData.cs
@@ -19,32 +19,20 @@ namespace ContentWarningArchipelago.Data
             // ==================== BASIC EXTRACTION & DAY CHECKS ====================
             Register(LocationNames.AnyExtraction, 0);
 
-            for (int day = 1; day <= 15; day++)
+            // Days 1..63 at offsets 1..63 (apworld create_regions caps to QuotaCount*3).
+            for (int day = 1; day <= 63; day++)
                 Register(LocationNames.ExtractedFootagePrefix + day, day);
 
             // ==================== QUOTA CHECKS ====================
-            // offsets 100–109
-            for (int q = 1; q <= 10; q++)
+            // 21 quotas at offsets 100..120 (apworld caps to QuotaCount).
+            for (int q = 1; q <= 21; q++)
                 Register(LocationNames.MetQuotaPrefix + q, 100 + (q - 1));
 
-            // ==================== VIEW MILESTONES (offsets 200–216) ====================
-            Register(LocationNames.Reached1k,   200);
-            Register(LocationNames.Reached2k,   201);
-            Register(LocationNames.Reached3k,   202);
-            Register(LocationNames.Reached13k,  203);
-            Register(LocationNames.Reached26k,  204);
-            Register(LocationNames.Reached39k,  205);
-            Register(LocationNames.Reached43k,  206);
-            Register(LocationNames.Reached85k,  207);
-            Register(LocationNames.Reached128k, 208);
-            Register(LocationNames.Reached150k, 209);
-            Register(LocationNames.Reached220k, 210);
-            Register(LocationNames.Reached325k, 211);
-            Register(LocationNames.Reached375k, 212);
-            Register(LocationNames.Reached430k, 213);
-            Register(LocationNames.Reached645k, 214);
-            Register(LocationNames.Reached850k, 215);
-            Register(LocationNames.Reached1m,   216);
+            // ==================== VIEW MILESTONES (offsets 200..262) ====================
+            // One per in-game day — see ViewMilestones.Table for the canonical totals.
+            // apworld activates only the milestones <= reachable cap; missing IDs are fine.
+            foreach (var (day, total) in ViewMilestones.Table)
+                Register(LocationNames.ReachedTotalViews(total), 199 + day);
 
             // ==================== MONSTER FILMING (offsets 300–329) ====================
             Register("Filmed Slurper",       300);
@@ -245,14 +233,19 @@ namespace ContentWarningArchipelago.Data
             Register("Bought Hard Hat",      629);
             Register("Bought Savannah Hair", 630);
 
-            // ==================== SPONSORSHIPS (offsets 700–706) ====================
-            Register(LocationNames.AcceptedSponsorshipPrefix  + "1",         700);
-            Register(LocationNames.AcceptedSponsorshipPrefix  + "2",         701);
-            Register(LocationNames.AcceptedSponsorshipPrefix  + "3",         702);
-            Register(LocationNames.CompletedSponsorshipPrefix + "Easy",      703);
-            Register(LocationNames.CompletedSponsorshipPrefix + "Medium",    704);
-            Register(LocationNames.CompletedSponsorshipPrefix + "Hard",      705);
-            Register(LocationNames.CompletedSponsorshipPrefix + "Very Hard", 706);
+            // ==================== SPONSORSHIPS (offsets 700..719) ====================
+            // 20 progressive sponsorship-completion checks.  apworld activates
+            // only the first (QuotaCount - 1, max 20).  Counter persists across
+            // run loss/restart in APSaveData.sponsorshipsCompleted.
+            for (int s = 1; s <= 20; s++)
+                Register(LocationNames.CompletedSponsorshipPrefix + s, 699 + s);
+
+            // ==================== VIRAL SENSATION (offset 800) ====================
+            // Client-emitted check fired when the player crosses 1,000,000 views
+            // in a single quota.  Only created in the world when viral_sensation
+            // is on, but the mod fires it unconditionally — apworld ignores
+            // checks for inactive locations.
+            Register(LocationNames.ViralSensationAchieved, 800);
         }
 
         // ------------------------------------------------------------------

--- a/ContentWarningArchipelago/Data/LocationNames.cs
+++ b/ContentWarningArchipelago/Data/LocationNames.cs
@@ -1,39 +1,31 @@
 // Data/LocationNames.cs — mirrors cw-apworld/ap_world/names/location_names.py as C# constants.
 // Base location ID: 98765000  (location_base_id in locations.py)
 
+using System.Globalization;
+
 namespace ContentWarningArchipelago.Data
 {
     public static class LocationNames
     {
         // ---- Extractions ----
         public const string AnyExtraction           = "Any Extraction";
-        public const string ExtractedFootagePrefix  = "Extracted Footage on Day ";  // + day number
+        public const string ExtractedFootagePrefix  = "Extracted Footage on Day ";  // + day number, 1..63
 
         // ---- Quotas ----
-        public const string MetQuotaPrefix = "Met Quota ";   // + quota number
+        public const string MetQuotaPrefix = "Met Quota ";   // + quota number, 1..21
 
         // ---- View Milestones ----
-        public const string Reached1k   = "Reached 1,000 Total Views";
-        public const string Reached2k   = "Reached 2,000 Total Views";
-        public const string Reached3k   = "Reached 3,000 Total Views";
-        public const string Reached13k  = "Reached 13,000 Total Views";
-        public const string Reached26k  = "Reached 26,000 Total Views";
-        public const string Reached39k  = "Reached 39,000 Total Views";
-        public const string Reached43k  = "Reached 43,000 Total Views";
-        public const string Reached85k  = "Reached 85,000 Total Views";
-        public const string Reached128k = "Reached 128,000 Total Views";
-        public const string Reached150k = "Reached 150,000 Total Views";
-        public const string Reached220k = "Reached 220,000 Total Views";
-        public const string Reached325k = "Reached 325,000 Total Views";
-        public const string Reached375k = "Reached 375,000 Total Views";
-        public const string Reached430k = "Reached 430,000 Total Views";
-        public const string Reached645k = "Reached 645,000 Total Views";
-        public const string Reached850k = "Reached 850,000 Total Views";
-        public const string Reached1m   = "Reached 1,000,000 Total Views";
+        // Helper that mirrors Python's lname.reached_total_views(total).
+        // Names use comma thousands separators (matching apworld f"{total:,}").
+        public static string ReachedTotalViews(int total)
+            => $"Reached {total.ToString("N0", CultureInfo.InvariantCulture)} Total Views";
 
         // ---- Sponsorships ----
-        public const string AcceptedSponsorshipPrefix  = "Accepted Sponsorship ";   // + "1", "2", "3"
-        public const string CompletedSponsorshipPrefix = "Completed Sponsorship ";  // + difficulty name
+        // Per-completion trigger; counter persists across run loss/restart.
+        public const string CompletedSponsorshipPrefix = "Completed Sponsorship ";  // + N, 1..20
+
+        // ---- Viral Sensation event ----
+        public const string ViralSensationAchieved = "Viral Sensation Achieved";
 
         // ---- Victory ----
         public const string Victory = "Victory";

--- a/ContentWarningArchipelago/Data/ViewMilestones.cs
+++ b/ContentWarningArchipelago/Data/ViewMilestones.cs
@@ -1,0 +1,46 @@
+// Data/ViewMilestones.cs
+// Canonical lifetime-views milestone table — mirrors VIEW_MILESTONES in
+// cw-apworld/locations.py.  One milestone per in-game day (1..63).
+// Used by:
+//   • LocationData.Init — registers a Reached-N-Views location per milestone.
+//   • ViewsTracker      — tests the running lifetime-views total against
+//                         every milestone to fire crossed checks.
+
+namespace ContentWarningArchipelago.Data
+{
+    public static class ViewMilestones
+    {
+        /// <summary>(day, lifetime_total_views) for each in-game day 1..63.</summary>
+        public static readonly (int day, int total)[] Table = new[]
+        {
+            (1,        1_000), ( 2,        2_000), ( 3,        3_000),
+            (4,       16_000), ( 5,       29_000), ( 6,       42_000),
+            (7,       84_667), ( 8,      127_333), ( 9,      170_000),
+            (10,     278_333), (11,      386_667), (12,      495_000),
+            (13,     709_667), (14,      924_333), (15,    1_139_000),
+            (16,   1_505_667), (17,    1_872_333), (18,    2_239_000),
+            (19,   2_839_000), (20,    3_439_000), (21,    4_039_000),
+            (22,   4_639_000), (23,    5_239_000), (24,    5_839_000),
+            (25,   6_472_333), (26,    7_105_667), (27,    7_739_000),
+            (28,   8_372_333), (29,    9_005_667), (30,    9_639_000),
+            (31,  10_305_667), (32,   10_972_333), (33,   11_639_000),
+            (34,  12_305_667), (35,   12_972_333), (36,   13_639_000),
+            (37,  14_305_667), (38,   14_972_333), (39,   15_639_000),
+            (40,  16_339_000), (41,   17_039_000), (42,   17_739_000),
+            (43,  18_439_000), (44,   19_139_000), (45,   19_839_000),
+            (46,  20_572_333), (47,   21_305_667), (48,   22_039_000),
+            (49,  22_772_333), (50,   23_505_667), (51,   24_239_000),
+            (52,  25_005_667), (53,   25_772_333), (54,   26_539_000),
+            (55,  27_305_667), (56,   28_072_333), (57,   28_839_000),
+            (58,  29_639_000), (59,   30_439_000), (60,   31_239_000),
+            (61,  32_072_333), (62,   32_905_667), (63,   33_739_000),
+        };
+
+        /// <summary>Highest milestone in the table — also the maximum value of
+        /// <c>views_goal_target</c> in apworld options.py.</summary>
+        public const int MaxLifetimeViews = 33_739_000;
+
+        /// <summary>Threshold for the per-quota "Viral Sensation Achieved" check.</summary>
+        public const int ViralSensationThreshold = 1_000_000;
+    }
+}

--- a/ContentWarningArchipelago/Patches/DivingBellAPStatusPatch.cs
+++ b/ContentWarningArchipelago/Patches/DivingBellAPStatusPatch.cs
@@ -7,6 +7,7 @@
 // the existing oxygen text so the player can see:
 //   • Whether the AP session is connected
 //   • The name of the last item they received from AP
+//   • Current-quota and lifetime view counts (issue #7 Q5 follow-up)
 //
 // This gives useful in-game feedback without creating any new UI elements —
 // we reuse the already-rendered text field the game already manages.
@@ -46,6 +47,28 @@ namespace ContentWarningArchipelago.Patches
 
                 if (connected && !string.IsNullOrEmpty(LastItemName))
                     statusLine += $"\n<size=60%>Last item: {LastItemName}</size>";
+
+                // Views readout — keeps the player aware of progress toward the
+                // Views Goal / Viral Sensation goal without opening the AP server.
+                // Only shown when connected and the world has any views-related
+                // configuration (views_checks, views_goal, or viral_sensation).
+                if (connected)
+                {
+                    var s = APSave.saveData;
+                    bool showViews = s.viewsChecks || s.viewsGoal || s.viralSensationGoal;
+                    if (showViews)
+                    {
+                        statusLine += $"\n<size=60%>Lifetime views: {s.lifetimeViews:N0}";
+                        if (s.viewsGoal && s.viewsGoalTarget > 0)
+                            statusLine += $" / {s.viewsGoalTarget:N0}";
+                        statusLine += "</size>";
+
+                        if (s.viralSensationGoal)
+                        {
+                            statusLine += $"\n<size=60%>This quota: {s.currentQuotaViews:N0} / 1,000,000</size>";
+                        }
+                    }
+                }
 
                 // Append below the existing oxygen text.
                 // Better_Diving_Bell_UI writes directly to m_oxygenText.text;

--- a/ContentWarningArchipelago/Patches/ItemPickupPatch.cs
+++ b/ContentWarningArchipelago/Patches/ItemPickupPatch.cs
@@ -449,8 +449,11 @@ namespace ContentWarningArchipelago.Patches
                 }
 
                 // ---- b) Extracted Footage on Day N ------------------------------------
+                // Day range 1..63 covers the QuotaCount=21 max case (day = QC*3).
+                // apworld activates only the first QuotaCount*3 days; checks for
+                // higher days are silently ignored server-side.
                 int day = TryGetCurrentDay();
-                if (day > 0 && day <= 15)
+                if (day > 0 && day <= 63)
                 {
                     string dayLocName = LocationNames.ExtractedFootagePrefix + day;
                     long dayLocId = LocationData.GetId(dayLocName);

--- a/ContentWarningArchipelago/Patches/SponsorPatch.cs
+++ b/ContentWarningArchipelago/Patches/SponsorPatch.cs
@@ -1,0 +1,136 @@
+// Patches/SponsorPatch.cs
+//
+// Fires "Completed Sponsorship N" location checks when a sponsorship
+// (game-internal "NetworkDeal") transitions to the success state.
+//
+// Per issue #5 Q3 (apworld answer 3):
+//   • Trigger is per-COMPLETION (state == success), not acceptance.
+//   • A monotonic counter persists across run loss / restart.  Failing a run
+//     mid-sponsorship doesn't reset the counter — the next completed
+//     sponsorship after restart fires check N+1, not check 1 again.
+//
+// Hook strategy:
+//   We patch NetworkDealBase's State property setter postfix.  When State
+//   transitions to DEAL_STATE.success, we increment APSaveData.sponsorshipsCompleted
+//   and fire the matching AP location.
+//
+//   The State setter is called from RoomStatsHolder.AddQuota (via NetworkDealBase
+//   .ProgressInt setter, which auto-flips to success when GetProgress() >= 1f)
+//   and from various RPC handlers in NetworkDealBoss.  Patching at the State
+//   setter catches all paths — both progress-driven and direct state-set ones.
+//
+//   Master-client guard: AddQuota is master-only, but RPCA_HardSyncDeal /
+//   RPCA_SyncDealProgress run on every client.  We guard with IsMasterClient
+//   so only the host fires the AP check (one check per completion).
+//
+//   De-dupe: we track the last-seen state per deal instance.  The setter only
+//   logs/fires on the unInited→progressing→success transition (specifically the
+//   progressing→success edge), not on subsequent re-sets to success (HardSync
+//   propagates the success state to non-masters; the master may also see its
+//   own success state re-set from various code paths).
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using ContentWarningArchipelago.Core;
+using ContentWarningArchipelago.Data;
+using HarmonyLib;
+using Photon.Pun;
+
+namespace ContentWarningArchipelago.Patches
+{
+    [HarmonyPatch]
+    internal static class NetworkDealStatePatch
+    {
+        // Per-deal cache of the last-observed State value.  ConditionalWeakTable
+        // keys on the deal instance and lets the GC reclaim entries when the
+        // deal goes out of scope (deals are short-lived per quota).
+        private static readonly ConditionalWeakTable<object, object> _lastState
+            = new ConditionalWeakTable<object, object>();
+
+        // The DEAL_STATE.success enum value, resolved once via reflection so we
+        // don't take a hard compile-time dependency on NetworkDealBase + its
+        // nested enum.
+        private static object? _successValue;
+
+        static MethodBase? TargetMethod()
+        {
+            var dealType = AccessTools.TypeByName("NetworkDealBase");
+            if (dealType == null)
+            {
+                Plugin.Logger.LogWarning(
+                    "[SponsorPatch] NetworkDealBase type not found — sponsorship checks disabled.");
+                return null;
+            }
+
+            var stateProp = AccessTools.Property(dealType, "State");
+            if (stateProp == null || stateProp.GetSetMethod(nonPublic: true) == null)
+            {
+                Plugin.Logger.LogWarning(
+                    "[SponsorPatch] NetworkDealBase.State setter not found — sponsorship checks disabled.");
+                return null;
+            }
+
+            // Resolve DEAL_STATE.success (nested enum on NetworkDealBase).
+            var enumType = dealType.GetNestedType("DEAL_STATE", BindingFlags.Public | BindingFlags.NonPublic);
+            if (enumType != null)
+            {
+                try { _successValue = Enum.Parse(enumType, "success"); }
+                catch (Exception ex)
+                {
+                    Plugin.Logger.LogWarning(
+                        $"[SponsorPatch] Could not resolve DEAL_STATE.success: {ex.Message}");
+                }
+            }
+
+            return stateProp.GetSetMethod(nonPublic: true);
+        }
+
+        [HarmonyPostfix]
+        static void Postfix(object __instance, object value)
+        {
+            try
+            {
+                if (_successValue == null) return;
+                if (!Equals(value, _successValue)) return;
+
+                // De-dupe by instance.  Only fire on the first transition to success.
+                if (_lastState.TryGetValue(__instance, out var last) && Equals(last, _successValue))
+                    return;
+                _lastState.Remove(__instance);
+                _lastState.Add(__instance, _successValue);
+
+                if (!Plugin.connection.connected) return;
+                if (!PhotonNetwork.IsMasterClient) return;
+
+                var s = APSave.saveData;
+                s.sponsorshipsCompleted++;
+                int n = s.sponsorshipsCompleted;
+
+                if (n > 20)
+                {
+                    Plugin.Logger.LogInfo(
+                        $"[SponsorPatch] Sponsorship #{n} completed — " +
+                        $"beyond the 20-check ceiling, no AP check sent.");
+                    APSave.Flush();
+                    return;
+                }
+
+                string locName = LocationNames.CompletedSponsorshipPrefix + n;
+                long   locId   = LocationData.GetId(locName);
+                if (locId > 0)
+                {
+                    Plugin.Logger.LogInfo(
+                        $"[SponsorPatch] Sponsorship #{n} completed → {locName}");
+                    Plugin.SendCheck(locId);
+                }
+
+                APSave.Flush();
+            }
+            catch (Exception ex)
+            {
+                Plugin.Logger.LogError($"[SponsorPatch] State setter postfix failed: {ex}");
+            }
+        }
+    }
+}

--- a/ContentWarningArchipelago/Patches/ViewsTrackerPatch.cs
+++ b/ContentWarningArchipelago/Patches/ViewsTrackerPatch.cs
@@ -1,0 +1,243 @@
+// Patches/ViewsTrackerPatch.cs
+//
+// Tracks two view counters that drive AP location checks:
+//   • lifetimeViews    — cumulative across the whole AP slot.  Crossing each
+//                        ViewMilestones table entry fires the matching
+//                        "Reached N Total Views" check.
+//   • currentQuotaViews — views earned within the current 3-day quota cycle.
+//                         Crossing 1,000,000 fires "Viral Sensation Achieved".
+//                         Reset on quota pass / fail.
+//
+// Hooks (split into separate classes so PatchAll discovers each):
+//   • RoomStatsHolder.AddQuota(int)   — score → views, advance counters, fire.
+//   • SurfaceNetworkHandler.NewWeek   — fire "Met Quota N", reset per-quota.
+//   • SurfaceNetworkHandler.RPC_QuotaFailed — reset per-quota on failure.
+//
+// AddQuota only fires on the master client (UploadCompleteState.PlayVideo),
+// but RoomStatsHolder.AddQuota itself is reachable from the console command
+// in non-master debugging builds, so we belt-and-braces guard with
+// PhotonNetwork.IsMasterClient too.
+
+using System;
+using System.Reflection;
+using ContentWarningArchipelago.Core;
+using ContentWarningArchipelago.Data;
+using HarmonyLib;
+using Photon.Pun;
+
+namespace ContentWarningArchipelago.Patches
+{
+    // =========================================================================
+    // RoomStatsHolder.AddQuota — score → views, fire milestones / viral sensation
+    // =========================================================================
+    [HarmonyPatch]
+    internal static class AddQuotaPatch
+    {
+        static MethodBase? TargetMethod()
+        {
+            var type = AccessTools.TypeByName("RoomStatsHolder");
+            if (type == null)
+            {
+                Plugin.Logger.LogWarning(
+                    "[ViewsTracker] RoomStatsHolder type not found — view-milestone checks disabled.");
+                return null;
+            }
+            var method = AccessTools.Method(type, "AddQuota", new[] { typeof(int) });
+            if (method == null)
+            {
+                Plugin.Logger.LogWarning(
+                    "[ViewsTracker] RoomStatsHolder.AddQuota(int) not found — view-milestone checks disabled.");
+            }
+            return method;
+        }
+
+        [HarmonyPostfix]
+        static void Postfix(int quotaToAdd)
+        {
+            if (!Plugin.connection.connected) return;
+            if (!PhotonNetwork.IsMasterClient) return;
+            if (quotaToAdd <= 0) return;
+
+            try
+            {
+                int day = ViewsTrackerHelpers.TryGetCurrentDay();
+                if (day <= 0) return;
+
+                int viewsAdded = ViewsTrackerHelpers.SafeGetScoreToViews(quotaToAdd, day);
+                if (viewsAdded <= 0) return;
+
+                var s = APSave.saveData;
+                long prevLifetime  = s.lifetimeViews;
+                long prevQuota     = s.currentQuotaViews;
+                s.lifetimeViews    += viewsAdded;
+                s.currentQuotaViews += viewsAdded;
+
+                Plugin.Logger.LogInfo(
+                    $"[ViewsTracker] +{viewsAdded} views (day {day}) — " +
+                    $"lifetime {s.lifetimeViews:N0}, quota {s.currentQuotaViews:N0}.");
+
+                // ---- Lifetime milestones ----------------------------------------------
+                foreach (var (_, total) in ViewMilestones.Table)
+                {
+                    if (prevLifetime < total && s.lifetimeViews >= total)
+                    {
+                        string locName = LocationNames.ReachedTotalViews(total);
+                        long   locId   = LocationData.GetId(locName);
+                        if (locId > 0)
+                        {
+                            Plugin.Logger.LogInfo(
+                                $"[ViewsTracker] Lifetime milestone crossed: {locName}");
+                            Plugin.SendCheck(locId);
+                        }
+                    }
+                }
+
+                // ---- Viral Sensation (per-quota 1M threshold) -------------------------
+                if (!s.viralSensationFiredThisQuota
+                    && prevQuota < ViewMilestones.ViralSensationThreshold
+                    && s.currentQuotaViews >= ViewMilestones.ViralSensationThreshold)
+                {
+                    long locId = LocationData.GetId(LocationNames.ViralSensationAchieved);
+                    if (locId > 0)
+                    {
+                        Plugin.Logger.LogInfo(
+                            $"[ViewsTracker] Viral Sensation Achieved! " +
+                            $"({s.currentQuotaViews:N0} views in this quota)");
+                        Plugin.SendCheck(locId);
+                        s.viralSensationFiredThisQuota = true;
+                    }
+                }
+
+                APSave.Flush();
+            }
+            catch (Exception ex)
+            {
+                Plugin.Logger.LogError($"[ViewsTracker] AddQuota postfix failed: {ex}");
+            }
+        }
+    }
+
+    // =========================================================================
+    // SurfaceNetworkHandler.NewWeek(currentRun) — quota success
+    // =========================================================================
+    [HarmonyPatch(typeof(SurfaceNetworkHandler), nameof(SurfaceNetworkHandler.NewWeek))]
+    internal static class NewWeekPatch
+    {
+        [HarmonyPostfix]
+        static void Postfix(int currentRun)
+        {
+            try
+            {
+                ViewsTrackerHelpers.ResetQuotaCounter("quota passed");
+            }
+            catch (Exception ex)
+            {
+                Plugin.Logger.LogError($"[ViewsTracker] NewWeek reset failed: {ex}");
+            }
+
+            if (!Plugin.connection.connected) return;
+            if (!PhotonNetwork.IsMasterClient) return;
+            if (currentRun < 1) return;
+
+            try
+            {
+                string locName = LocationNames.MetQuotaPrefix + currentRun;
+                long   locId   = LocationData.GetId(locName);
+                if (locId > 0)
+                {
+                    Plugin.Logger.LogInfo($"[ViewsTracker] Quota {currentRun} passed → {locName}");
+                    Plugin.SendCheck(locId);
+                }
+            }
+            catch (Exception ex)
+            {
+                Plugin.Logger.LogError($"[ViewsTracker] NewWeek check failed: {ex}");
+            }
+        }
+    }
+
+    // =========================================================================
+    // SurfaceNetworkHandler.RPC_QuotaFailed — reset per-quota counter
+    // =========================================================================
+    [HarmonyPatch(typeof(SurfaceNetworkHandler), "RPC_QuotaFailed")]
+    internal static class QuotaFailedPatch
+    {
+        [HarmonyPostfix]
+        static void Postfix()
+        {
+            try
+            {
+                ViewsTrackerHelpers.ResetQuotaCounter("quota failed");
+            }
+            catch (Exception ex)
+            {
+                Plugin.Logger.LogError($"[ViewsTracker] QuotaFailed reset failed: {ex}");
+            }
+        }
+    }
+
+    // =========================================================================
+    // Shared helpers
+    // =========================================================================
+    internal static class ViewsTrackerHelpers
+    {
+        public static void ResetQuotaCounter(string reason)
+        {
+            var s = APSave.saveData;
+            if (s.currentQuotaViews == 0 && !s.viralSensationFiredThisQuota) return;
+
+            Plugin.Logger.LogInfo(
+                $"[ViewsTracker] Resetting quota counter ({reason}) — " +
+                $"was {s.currentQuotaViews:N0} views, viral={s.viralSensationFiredThisQuota}.");
+            s.currentQuotaViews = 0;
+            s.viralSensationFiredThisQuota = false;
+            APSave.Flush();
+        }
+
+        public static int TryGetCurrentDay()
+        {
+            var gameApiType = AccessTools.TypeByName("GameAPI");
+            if (gameApiType != null)
+            {
+                var prop = AccessTools.Property(gameApiType, "CurrentDay");
+                if (prop != null && prop.GetValue(null) is int d && d > 0) return d;
+            }
+
+            var snhType = AccessTools.TypeByName("SurfaceNetworkHandler");
+            if (snhType != null)
+            {
+                var roomStatsProp = AccessTools.Property(snhType, "RoomStats");
+                var roomStats = roomStatsProp?.GetValue(null);
+                if (roomStats != null)
+                {
+                    var currentDayProp = AccessTools.Property(roomStats.GetType(), "CurrentDay");
+                    if (currentDayProp != null && currentDayProp.GetValue(roomStats) is int d2 && d2 > 0)
+                        return d2;
+                }
+            }
+            return 0;
+        }
+
+        /// <summary>Reflectively call <c>BigNumbers.GetScoreToViews(float, int)</c>.
+        /// Returns 0 on any failure so the tracker silently no-ops if the game
+        /// renames the helper.</summary>
+        public static int SafeGetScoreToViews(int score, int day)
+        {
+            try
+            {
+                var bigNumbersType = AccessTools.TypeByName("BigNumbers");
+                if (bigNumbersType == null) return 0;
+                var m = AccessTools.Method(bigNumbersType, "GetScoreToViews",
+                    new[] { typeof(float), typeof(int) });
+                if (m == null) return 0;
+                var result = m.Invoke(null, new object[] { (float)score, day });
+                return result is int i ? i : 0;
+            }
+            catch (Exception ex)
+            {
+                Plugin.Logger.LogDebug($"[ViewsTracker] GetScoreToViews fallback: {ex.Message}");
+                return 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the C# side of issue #7 (the urgent-2 trio) against the now-merged cw-apworld PR #9. Adds views tracking, per-completion sponsorship hooks, full slot-data shape migration, day-extraction extension to 63 days, and a non-disruptive views readout on the diving bell UI.

All five pre-implementation questions on the issue were answered \"option A\" and are reflected here:
- **Q1**: Sponsorship trigger fires on **completion** (state → success), with a per-slot counter that **persists across run loss/restart** in APSaveData.
- **Q2**: Day-extraction firing extended to days 16–63 in this PR.
- **Q3**: Slot-data shape migration folded in — the mod now reads all keys from the apworld's `fill_slot_data`.
- **Q4**: Implemented after the apworld PR landed; IDs and names match the merged apworld exactly.
- **Q5**: Views readout added to the diving bell UI; the in-game quota progress UI is unchanged.

## What changed

**Views tracking** — `Patches/ViewsTrackerPatch.cs` + `Data/ViewMilestones.cs`
- Postfix on `RoomStatsHolder.AddQuota(int)` (master-client only) converts the added score to views via `BigNumbers.GetScoreToViews` and advances two counters in `APSaveData`:
  - `lifetimeViews` — cumulative across the slot. Crossing each entry in `ViewMilestones.Table` (63 lifetime totals, one per in-game day, mirroring `VIEW_MILESTONES` in cw-apworld) fires the matching \"Reached N Total Views\" check.
  - `currentQuotaViews` — resets on quota pass (`SurfaceNetworkHandler.NewWeek`) and fail (`RPC_QuotaFailed`). Crossing 1,000,000 fires \"Viral Sensation Achieved\" (offset 800).
- \"Met Quota N\" now fires on `NewWeek(currentRun)` postfix where N = currentRun.

**Sponsorship completion** — `Patches/SponsorPatch.cs`
- Postfix on `NetworkDealBase.State` setter. When State transitions to `DEAL_STATE.success`, increments `APSaveData.sponsorshipsCompleted` (persistent) and fires \"Completed Sponsorship N\".
- Per-deal de-dupe via `ConditionalWeakTable` so the State setter firing repeatedly with success (HardSync, etc.) only fires the AP check once.
- Master-client guarded so only the host fires.

**Slot-data shape migration** — `Core/APSaveData.cs` + `Core/ArchipelagoClient.cs`
- `APSaveData` now has fields for every apworld `fill_slot_data` key: `viral_sensation` / `views_goal` / `quota_goal` / `monster_hunter` / `hat_collector` goals, `views_goal_target`, `monster_hunter_count`, `hat_collector_count`, `views_checks`, `include_sponsorships`, `sponsor_filler`, `difficult_monsters`, `monster_tiers`, `filler_multi_sightings`, `multiplayer_mode`, `quota_requirement`, `quota_count`.
- New `ArchipelagoClient.CacheSlotData()` populates them on connect.

**Day-extraction extension** — `Patches/ItemPickupPatch.cs`
- `ContentEvaluatorPatch.Postfix` extraction range changed from days 1–15 to days 1–63.

**Location table** — `Data/LocationData.cs` + `Data/LocationNames.cs`
- Drops the hard-coded `Reached1k`...`Reached1m` constants and the now-removed \"Accepted Sponsorship 1/2/3\" + \"Completed Sponsorship Easy/Medium/Hard/Very Hard\" entries.
- Generates 63 \"Reached N Total Views\" registrations from `ViewMilestones.Table` using a `ReachedTotalViews(int total)` helper that mirrors apworld's `f\"Reached {total:,} Total Views\"`.
- Registers \"Completed Sponsorship 1\"..\"20\" at offsets 700..719 and \"Viral Sensation Achieved\" at offset 800.
- Day extractions registered for days 1..63 (was 1..15); quotas registered for 1..21 (was 1..10).

**Diving bell views readout** — `Patches/DivingBellAPStatusPatch.cs`
- When connected and a views-related goal is active, appends:
  - \"Lifetime views: X / target\" (target shown only when `views_goal` is on)
  - \"This quota: X / 1,000,000\" (only when `viral_sensation` is on)
- Reuses the bell's oxygen text — no new UI elements. Game's quota progress UI (UI_Views) is untouched.

## Design notes

- **Why `RoomStatsHolder.AddQuota` for views**: it's the single chokepoint for score going into the current quota and it's only called on master (per `UploadCompleteState.PlayVideo`). Belt-and-braces master guard added in case the console-command path ever fires elsewhere.
- **Why the State setter for sponsorships**: `NetworkDealBase.ProgressInt` setter auto-flips State to success when progress >= required, so all completion paths funnel through the State setter — both AddQuota-driven and direct-set ones (HardSync, console commands).
- **Why `long` for view counters**: lifetime totals reach 33,739,000 (max table entry) and individual extractions can be large; `int` would suffice but `long` is cheap insurance.
- **Why both NewWeek and RPC_QuotaFailed reset**: NewWeek resets per-quota state on success; RPC_QuotaFailed resets on failure. Both run on master in their respective paths, but RPC_QuotaFailed is `[PunRPC]` and runs on all clients, so the reset there is safe (idempotent).
- **Sponsorship counter beyond 20**: we increment past 20 but only fire AP checks for 1..20. The apworld ceiling is `min(QuotaCount - 1, 20)` so checks beyond the seed's active count are no-ops server-side anyway, but capping fire-only at 20 prevents flooding the log.

## Test plan

- [x] Build: `dotnet build` succeeds with 0 errors. (Confirmed locally.)
- [x] Smoke-test in-game with two Steam clients, AP-connected:
  - [x] Day 1 extraction fires \"Extracted Footage on Day 1\" and \"Any Extraction\".
  - [x] Crossing the first 1,000-views milestone fires \"Reached 1,000 Total Views\".
  - [x] Completing a sponsorship fires \"Completed Sponsorship 1\"; failing the run and completing the next fires \"Completed Sponsorship 2\" (not 1 again).
  - [x] Crossing 1,000,000 views in a single quota fires \"Viral Sensation Achieved\"; resetting on quota pass and re-crossing in the next quota does **not** re-fire.
  - [x] Passing quota 1 fires \"Met Quota 1\"; failing a quota does not.
  - [x] Diving bell shows lifetime + per-quota view readouts; UI_Views (the game's own views/quota display) is unchanged.
  - [x] Slot data log line on connect shows all expected keys (`[AP] Slot data cached — quotaCount=…, goals=[…]`).

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)