### PR TITLE
Add Chorby collectable checks scaled to QuotaCount (issue #14)

### DIFF
--- a/ContentWarningArchipelago/Core/APSaveData.cs
+++ b/ContentWarningArchipelago/Core/APSaveData.cs
@@ -152,6 +152,21 @@ namespace ContentWarningArchipelago.Core
 
         public int sponsorshipsCompleted = 0;
 
+        // ------------------------------------------------------------------ Chorby pickups (issue #14)
+        // Number of Chorbies picked up across the entire AP slot.  Used as the
+        // index for the next "Found Chorby N" check.  Persists across run
+        // loss/restart per issue #14.  Once it exceeds quotaCount, the
+        // SpawningPatch keeps spawning Chorby every dive but the PickupPatch
+        // destroys it silently and (once) broadcasts the lobby toast tracked by
+        // <see cref="allChorbyChecksFoundNotified"/>.
+
+        public int chorbiesFound = 0;
+
+        /// <summary>True once the "All Chorby checks found" lobby toast has
+        /// fired.  Suppresses repeat broadcasts on subsequent post-quota
+        /// pickups.</summary>
+        public bool allChorbyChecksFoundNotified = false;
+
         // ------------------------------------------------------------------ Hat shop (session-only)
 
         /// <summary>

--- a/ContentWarningArchipelago/Data/LocationData.cs
+++ b/ContentWarningArchipelago/Data/LocationData.cs
@@ -240,6 +240,13 @@ namespace ContentWarningArchipelago.Data
             for (int s = 1; s <= 20; s++)
                 Register(LocationNames.CompletedSponsorshipPrefix + s, 699 + s);
 
+            // ==================== FOUND CHORBY (offsets 720..740) ====================
+            // 21 progressive Chorby-pickup checks.  apworld activates exactly
+            // QuotaCount of them.  Counter persists across run loss/restart in
+            // APSaveData.chorbiesFound (issue #14).
+            for (int c = 1; c <= 21; c++)
+                Register(LocationNames.FoundChorbyPrefix + c, 719 + c);
+
             // ==================== VIRAL SENSATION (offset 800) ====================
             // Client-emitted check fired when the player crosses 1,000,000 views
             // in a single quota.  Only created in the world when viral_sensation

--- a/ContentWarningArchipelago/Data/LocationNames.cs
+++ b/ContentWarningArchipelago/Data/LocationNames.cs
@@ -24,6 +24,12 @@ namespace ContentWarningArchipelago.Data
         // Per-completion trigger; counter persists across run loss/restart.
         public const string CompletedSponsorshipPrefix = "Completed Sponsorship ";  // + N, 1..20
 
+        // ---- Chorby collectible (issue #14) ----
+        // One per Chorby pickup; counter persists across run loss/restart.
+        // apworld activates exactly QuotaCount of these (max 21).
+        public const string FoundChorbyPrefix = "Found Chorby ";  // + N, 1..21
+        public const string AllChorbyChecksFound = "All Chorby checks found";
+
         // ---- Viral Sensation event ----
         public const string ViralSensationAchieved = "Viral Sensation Achieved";
 

--- a/ContentWarningArchipelago/Patches/ChorbyPatches.cs
+++ b/ContentWarningArchipelago/Patches/ChorbyPatches.cs
@@ -1,0 +1,340 @@
+// Patches/ChorbyPatches.cs
+//
+// Chorby is a unique map-spawned Archipelago collectible (issue #14).
+// One Chorby spawns per dive; picking it up is intercepted, the GameObject
+// is destroyed, and a sequential "Found Chorby N" location check fires.
+// QuotaCount controls how many checks exist (max 21).
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH 1 — ChorbySpawnPatch
+//   Target : RoundArtifactSpawner.GetArtifactsToSpawn(int, float)  [private]
+//
+//   WHY THIS METHOD:
+//   RoundArtifactSpawner.Start() runs once per dive on the master client and
+//   calls SpawnRound → GetArtifactsToSpawn → CreateArtifactSpawners.
+//   GetArtifactsToSpawn returns the list of Items the dive will spawn,
+//   weighted by Item.rarity and the per-day budget.  Chorby's vanilla rarity
+//   is ~0.005, so it almost never makes the list.
+//
+//   We postfix the result list to:
+//     1. Remove any vanilla-picked Chorby entries (cap to 0).
+//     2. Insert exactly one Chorby reference.
+//   CreateArtifactSpawners then spawns one ArtifactSpawner for it like any
+//   other artifact, so it lands at a randomised PatrolPoint and behaves
+//   normally apart from our pickup interception.
+//
+//   No master-client guard needed — Start() already gates the only caller
+//   with PhotonNetwork.IsMasterClient.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH 2 — ChorbyPickupPatch
+//   Target : Pickup.RPC_RequestPickup(int photonView)  [PunRPC, master-only]
+//
+//   WHY THIS METHOD:
+//   Pickup.Interact sends RPC_RequestPickup to the master client; the master
+//   is the single authority that decides whether the pickup succeeds.  By
+//   prefixing this method we can:
+//     1. Detect a Chorby pickup attempt (by Item.name).
+//     2. Cancel the vanilla pickup so Chorby never enters inventory.
+//     3. Destroy the GameObject network-wide via RPC_Remove.
+//     4. Increment APSaveData.chorbiesFound, send the AP check.
+//
+//   Past quotaCount, all subsequent Chorbies are destroyed silently.  The
+//   first such over-cap pickup broadcasts the "All Chorby checks found"
+//   lobby toast via Mycelium; subsequent ones suppress the broadcast.
+//
+//   Master-client guard: implicit — RPC_RequestPickup only executes on the
+//   master client (Pickup.Interact targets RpcTarget.MasterClient).  We add
+//   a defensive PhotonNetwork.IsMasterClient guard anyway.
+// ─────────────────────────────────────────────────────────────────────────────
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using ContentWarningArchipelago.Core;
+using ContentWarningArchipelago.Data;
+using ContentWarningArchipelago.UI;
+using HarmonyLib;
+using MyceliumNetworking;
+using Photon.Pun;
+using Steamworks;
+
+namespace ContentWarningArchipelago.Patches
+{
+    // =========================================================================
+    // PATCH 1 — Force exactly one Chorby into the per-dive artifact list
+    // =========================================================================
+    [HarmonyPatch]
+    internal static class ChorbySpawnPatch
+    {
+        // The Chorby Item asset, resolved lazily once the spawner exposes its
+        // possibleSpawns array.  Comparing by reference is safe because the
+        // ItemDatabase / SingletonAsset returns the same instance each call.
+        private static object? _chorbyItem;
+
+        static MethodBase? TargetMethod()
+        {
+            var type = AccessTools.TypeByName("RoundArtifactSpawner");
+            if (type == null)
+            {
+                Plugin.Logger.LogWarning(
+                    "[ChorbySpawnPatch] RoundArtifactSpawner type not found — Chorby spawn-cap disabled.");
+                return null;
+            }
+
+            var method = AccessTools.Method(type, "GetArtifactsToSpawn");
+            if (method == null)
+            {
+                Plugin.Logger.LogWarning(
+                    "[ChorbySpawnPatch] GetArtifactsToSpawn method not found — Chorby spawn-cap disabled.");
+                return null;
+            }
+
+            Plugin.Logger.LogInfo($"[ChorbySpawnPatch] Patching {type.Name}.{method.Name}");
+            return method;
+        }
+
+        [HarmonyPostfix]
+        static void Postfix(object __instance, object __result)
+        {
+            try
+            {
+                if (__result is not System.Collections.IList resultList)
+                {
+                    Plugin.Logger.LogWarning(
+                        "[ChorbySpawnPatch] GetArtifactsToSpawn returned a non-IList — Chorby skipped this dive.");
+                    return;
+                }
+
+                // Resolve Chorby once via the spawner's possibleSpawns array.
+                if (_chorbyItem == null)
+                    _chorbyItem = ResolveChorby(__instance);
+
+                if (_chorbyItem == null)
+                {
+                    Plugin.Logger.LogWarning(
+                        "[ChorbySpawnPatch] Chorby Item not found in possibleSpawns — Chorby skipped this dive.");
+                    return;
+                }
+
+                // Strip any vanilla Chorby picks (cap from 0 from the random pool)…
+                int removed = 0;
+                for (int i = resultList.Count - 1; i >= 0; i--)
+                {
+                    if (ReferenceEquals(resultList[i], _chorbyItem))
+                    {
+                        resultList.RemoveAt(i);
+                        removed++;
+                    }
+                }
+
+                // …then insert exactly one Chorby at the front of the list.
+                resultList.Insert(0, _chorbyItem);
+
+                Plugin.Logger.LogInfo(
+                    $"[ChorbySpawnPatch] Forced 1 Chorby into the artifact list " +
+                    $"(removed {removed} vanilla pick{(removed == 1 ? "" : "s")}, " +
+                    $"final count={resultList.Count}).");
+            }
+            catch (Exception ex)
+            {
+                Plugin.Logger.LogError($"[ChorbySpawnPatch] Postfix failed: {ex}");
+            }
+        }
+
+        /// <summary>
+        /// Walks <c>RoundArtifactSpawner.possibleSpawns</c> looking for the
+        /// Chorby Item by Unity asset name.  Returns null if absent.
+        /// </summary>
+        private static object? ResolveChorby(object spawnerInstance)
+        {
+            var possibleField = AccessTools.Field(spawnerInstance.GetType(), "possibleSpawns");
+            if (possibleField == null) return null;
+
+            if (possibleField.GetValue(spawnerInstance) is not System.Collections.IEnumerable items)
+                return null;
+
+            foreach (var item in items)
+            {
+                if (item is UnityEngine.Object uo &&
+                    string.Equals(uo.name, "Chorby", StringComparison.Ordinal))
+                {
+                    return item;
+                }
+            }
+            return null;
+        }
+    }
+
+    // =========================================================================
+    // PATCH 2 — Intercept Chorby pickup and convert it to an AP check
+    // =========================================================================
+    [HarmonyPatch]
+    internal static class ChorbyPickupPatch
+    {
+        static MethodBase? TargetMethod()
+        {
+            var type = AccessTools.TypeByName("Pickup");
+            if (type == null)
+            {
+                Plugin.Logger.LogWarning(
+                    "[ChorbyPickupPatch] Pickup type not found — Chorby pickup intercept disabled.");
+                return null;
+            }
+
+            var method = AccessTools.Method(type, "RPC_RequestPickup");
+            if (method == null)
+            {
+                Plugin.Logger.LogWarning(
+                    "[ChorbyPickupPatch] Pickup.RPC_RequestPickup not found — Chorby pickup intercept disabled.");
+                return null;
+            }
+
+            Plugin.Logger.LogInfo($"[ChorbyPickupPatch] Patching {type.Name}.{method.Name}");
+            return method;
+        }
+
+        /// <summary>
+        /// Returns false to skip the vanilla pickup body when the targeted
+        /// item is Chorby; otherwise lets the original method run normally.
+        /// </summary>
+        [HarmonyPrefix]
+        static bool Prefix(object __instance)
+        {
+            try
+            {
+                if (!IsChorby(__instance, out string itemName)) return true;
+
+                if (!PhotonNetwork.IsMasterClient)
+                {
+                    // Defensive — RPC_RequestPickup is RpcTarget.MasterClient,
+                    // so we should never reach here on a non-master.
+                    Plugin.Logger.LogDebug(
+                        "[ChorbyPickupPatch] Non-master client received RPC_RequestPickup — letting vanilla handle it.");
+                    return true;
+                }
+
+                Plugin.Logger.LogInfo($"[ChorbyPickupPatch] Chorby pickup intercepted ({itemName}).");
+
+                // Cap reached — broadcast once, then silent for the rest.
+                if (Plugin.connection.connected &&
+                    APSave.saveData.chorbiesFound >= APSave.saveData.quotaCount)
+                {
+                    if (!APSave.saveData.allChorbyChecksFoundNotified)
+                    {
+                        BroadcastAllChorbyChecksFound();
+                        APSave.saveData.allChorbyChecksFoundNotified = true;
+                        APSave.Flush();
+                    }
+                    DestroyPickup(__instance);
+                    return false;
+                }
+
+                // Standard path — increment, send the matching AP check.
+                if (Plugin.connection.connected)
+                {
+                    APSave.saveData.chorbiesFound++;
+                    int n = APSave.saveData.chorbiesFound;
+
+                    string locName = LocationNames.FoundChorbyPrefix + n;
+                    long   locId   = LocationData.GetId(locName);
+                    if (locId > 0)
+                    {
+                        Plugin.Logger.LogInfo(
+                            $"[ChorbyPickupPatch] Chorby #{n} picked up → {locName}");
+                        Plugin.SendCheck(locId);
+                    }
+                    else
+                    {
+                        Plugin.Logger.LogDebug(
+                            $"[ChorbyPickupPatch] Chorby #{n} above the 21-check ceiling — no AP check sent.");
+                    }
+
+                    APSave.Flush();
+                }
+
+                DestroyPickup(__instance);
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Plugin.Logger.LogError($"[ChorbyPickupPatch] Prefix failed: {ex}");
+                // Fall through to vanilla so a buggy patch doesn't soft-lock pickups.
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Reads <c>Pickup.m_itemID</c> via reflection, looks up the Item in
+        /// the database, and returns true when it's Chorby.
+        /// </summary>
+        private static bool IsChorby(object pickupInstance, out string itemName)
+        {
+            itemName = string.Empty;
+
+            var idField = AccessTools.Field(pickupInstance.GetType(), "m_itemID");
+            if (idField == null) return false;
+            if (idField.GetValue(pickupInstance) is not byte itemId) return false;
+
+            var dbType = AccessTools.TypeByName("ItemDatabase");
+            var tryGet = dbType != null ? AccessTools.Method(dbType, "TryGetItemFromID") : null;
+            if (tryGet == null) return false;
+
+            var args = new object[] { itemId, null! };
+            bool ok = (bool)(tryGet.Invoke(null, args) ?? false);
+            if (!ok || args[1] is not UnityEngine.Object item) return false;
+
+            itemName = item.name ?? string.Empty;
+            return string.Equals(itemName, "Chorby", StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Calls <c>m_photonView.RPC("RPC_Remove", RpcTarget.MasterClient)</c>
+        /// to network-destroy the pickup, mirroring the cleanup the vanilla
+        /// RPC_RequestPickup performs after a successful inventory add.
+        /// </summary>
+        private static void DestroyPickup(object pickupInstance)
+        {
+            try
+            {
+                var pvField = AccessTools.Field(pickupInstance.GetType(), "m_photonView");
+                if (pvField?.GetValue(pickupInstance) is not PhotonView pv) return;
+
+                pv.RPC("RPC_Remove", RpcTarget.MasterClient);
+            }
+            catch (Exception ex)
+            {
+                Plugin.Logger.LogWarning($"[ChorbyPickupPatch] DestroyPickup failed: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Shows the local "All Chorby checks found" toast and broadcasts it
+        /// to other lobby members via Mycelium so everyone sees the milestone.
+        /// </summary>
+        private static void BroadcastAllChorbyChecksFound()
+        {
+            string msg = LocationNames.AllChorbyChecksFound;
+
+            APNotificationUI.ShowLocationFound(msg);
+            Plugin.Logger.LogInfo($"[ChorbyPickupPatch] {msg} (post-quota Chorby pickup).");
+
+            if (PhotonNetwork.InRoom && PhotonNetwork.CurrentRoom.PlayerCount > 1)
+            {
+                try
+                {
+                    MyceliumNetwork.RPC(
+                        Plugin.MyceliumModId,
+                        nameof(Plugin.LocationFound),
+                        ReliableType.Reliable,
+                        msg);
+                }
+                catch (Exception ex)
+                {
+                    Plugin.Logger.LogWarning(
+                        $"[ChorbyPickupPatch] Mycelium broadcast failed: {ex.Message}");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the Chorby collectable mechanic from issue #14:

- **Forces 1 Chorby spawn per dive** via a postfix on `RoundArtifactSpawner.GetArtifactsToSpawn`. Strips any vanilla-picked Chorby entries (rate ~0.005) and inserts exactly one — vanilla `CreateArtifactSpawners` then places it at a randomised PatrolPoint like any other artifact.
- **Intercepts the pickup** via a prefix on `Pickup.RPC_RequestPickup`. When the targeted item is Chorby, the prefix cancels the vanilla inventory add, network-destroys the GameObject (`RPC_Remove`), and fires the matching `Found Chorby N` AP location check.
- **Counter persists across run loss** in `APSaveData.chorbiesFound` (per Jake's answer 3).
- **Spawns continue forever** post-cap (Jake's answer 2A); each over-cap pickup destroys silently. The first such pickup broadcasts "All Chorby checks found" to the lobby via Mycelium; subsequent ones are suppressed by `allChorbyChecksFoundNotified`.
- **Standard `APNotificationUI.ShowLocationFound` toast** on each successful check (Jake's answer 3).

## Design choices / assumptions

- **Hook choice — `GetArtifactsToSpawn` postfix vs. `Start` prefix.** Postfix lets vanilla compute the budget-driven list normally and only mutates the result, which keeps the artifact distribution intact. Replacing `Start` would mean reimplementing the budget/rarest-artifact logic and risks drifting if the game tweaks balance.
- **Chorby identification — `Item.name == "Chorby"` (Unity asset name).** Matches the wiki naming Jake provided. Resolved once on first call from `RoundArtifactSpawner.possibleSpawns` and cached.
- **No master-client guard on the spawn patch.** `GetArtifactsToSpawn` is private and only reached from `Start` which already has the `PhotonNetwork.IsMasterClient` gate.
- **Master-client guard on the pickup patch.** Defensive only — `Pickup.Interact` targets `RpcTarget.MasterClient`, so non-master clients should never see the prefix fire.
- **Single-shot lobby toast.** Issue text says "optionally notify"; broadcasting on every post-cap pickup felt spammy. The `allChorbyChecksFoundNotified` flag fires once and stays silent thereafter.
- **Location offsets 720..740** (21 entries for `Found Chorby 1..21`), adjacent to the existing sponsorship block at 700..719. **The matching cw-apworld PR must use the same offsets** — apworld issue will be filed separately.

## Cross-repo coordination

This PR depends on a sibling cw-apworld PR that:
1. Adds `Found Chorby N` location names at offsets 720..740 (matching this PR's `LocationData.cs`).
2. During world generation, reads `QuotaCount` and activates exactly that many Chorby locations.

I will file the apworld issue and PR in parallel.

## Test plan

- [x] Build cleanly (verified locally with `dotnet build`).
- [ ] Two Steam clients in the same lobby, AP slot with `quota_count = 5`:
  - [ ] Confirm exactly one Chorby spawns per dive (visible to both clients).
  - [ ] Pick up Chorby on master → vanilla pickup is cancelled, Chorby disappears, "Found Chorby 1" toast shows on master, AP server logs the check.
  - [ ] Repeat 5× across multiple dives → checks fire 1..5; lobby member also sees the toasts.
  - [ ] On the 6th Chorby pickup → no AP check fires, Chorby is destroyed, "All Chorby checks found" toast broadcasts to the lobby (both clients see it).
  - [ ] On the 7th+ pickup → Chorby destroyed silently, no toast.
- [ ] Restart the game mid-progression (e.g. after 3 Chorbies) → next Chorby fires `Found Chorby 4`, not `Found Chorby 1`.
- [ ] Pick up Chorby on a non-master client → behaviour is identical (master still authoritative).

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)